### PR TITLE
adding feature to set max k

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Lightweight Simulator of Recombination in Polyclonal Infections
 Version: 1.0.2
 Authors@R: as.person(c(
     "Bob Verity <r.verity@imperial.ac.uk> [aut, cre]", 
-    "Nick Hathaway <nicholas.hathaway@ucsf.edu> [aut, cre]"
+    "Nick Hathaway <nicholas.hathaway@ucsf.edu> [aut]"
   ))
 Description: recombuddy is a lightweight genetic simulation toolkit designed to model recombination
     and polyclonality, making it particularly well-suited for Plasmodium analysis. Its

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,13 @@
 Package: recombuddy
 Type: Package
 Title: Lightweight Simulator of Recombination in Polyclonal Infections
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: as.person(c(
-    "Bob Verity <r.verity@imperial.ac.uk> [aut, cre]"
+    "Bob Verity <r.verity@imperial.ac.uk> [aut, cre]", 
+    "Nick Hathaway <nicholas.hathaway@ucsf.edu> [aut, cre]"
   ))
 Description: recombuddy is a lightweight genetic simulation toolkit designed to model recombination
-    and polyclonality, making it particularly well-suited for Plasmodium falciparum analysis. Its
+    and polyclonality, making it particularly well-suited for Plasmodium analysis. Its
     streamlined simulation framework captures key patterns observed in real data—such as within-sample
     relatedness and mosaic haplotypes—without unnecessary complexity. The package provides core functionality
     for simulating recombination blocks, projecting marker loci onto these genomic patterns, and visualizing
@@ -21,5 +22,6 @@ Imports:
     ggplot2,
     MCMCpack,
     tibble,
-    tidyr
+    tidyr,
+    validate
 Depends: R (>= 4.1.0)

--- a/R/main.R
+++ b/R/main.R
@@ -579,6 +579,7 @@ generate_serial_meiosis_k <-function(coi_r, coi_p, k_s, max_coi = 100){
 #' @param pop_alpha the alpha parameter to set for the dirichlet function for the population proportions, lower alphas generate more closely related final populations
 #' @param coi_r,coi_p the r and p parameters to be given to the zero truncated negative binomial distribution COI generator `recombuddy::rztnbinom()` see `?rztnbinom` for more details
 #' @param k_s the s parameter to be given to the type 1 geometric distribution random generator function `rgeom()` to select for serial meiosis
+#' @param max_k the maximum k allowed
 #' @param max_coi the maximum allowable COI
 #' @param rho the recombination rate
 #' @param chrom_sizes a named vector of lengths of chromosome lengths
@@ -590,7 +591,7 @@ generate_serial_meiosis_k <-function(coi_r, coi_p, k_s, max_coi = 100){
 #' @examples
 #' # simulate pop_alpha 9 (~10% between sample relatedness), coi_r = 0.25, coi_p = 0.7 (COI mean of 1.256, ~80.4 proportion will be monoclonal), k_s = 0.5 (50% of genotypes will be recombinant)
 #' pop1 = sim_population(paste0("sample", seq(0,100,1)), 5, pop_alpha = 9, coi_r = 0.25, coi_p = 0.7, k_s = 0.5)
-sim_population <- function(input_samples, n_samples_out, pop_alpha, coi_r, coi_p, k_s, max_coi = 100, rho = 7.4e-7, chrom_sizes = get_pf3d7_chrom_sizes()){
+sim_population <- function(input_samples, n_samples_out, pop_alpha, coi_r, coi_p, k_s, max_k = 20, max_coi = 100, rho = 7.4e-7, chrom_sizes = get_pf3d7_chrom_sizes()){
   ret = list()
   # generate a index key tibble for samples
   input_samples_df = tibble(ancestral_genotype = input_samples) |> mutate(index = row_number())
@@ -602,7 +603,11 @@ sim_population <- function(input_samples, n_samples_out, pop_alpha, coi_r, coi_p
   # simulate samples
   ret[["simulated_samples"]] = list()
   for(samp in 1:n_samples_out){
-    ret[["simulated_samples"]][[samp]] = sim_sample(k = generate_serial_meiosis_k(coi_r = coi_r, coi_p = coi_p, k_s = k_s, max_coi = max_coi),
+    current_k = generate_serial_meiosis_k(coi_r = coi_r, coi_p = coi_p, k_s = k_s, max_coi = max_coi)
+    while(max(current_k) > max_k){
+      current_k = generate_serial_meiosis_k(coi_r = coi_r, coi_p = coi_p, k_s = k_s, max_coi = max_coi)
+    }
+    ret[["simulated_samples"]][[samp]] = sim_sample(k = current_k,
                                                     rho = rho,
                                                     set_props = set_props,
                                                     chrom_sizes = chrom_sizes)

--- a/R/main.R
+++ b/R/main.R
@@ -598,8 +598,18 @@ sim_population <- function(input_samples, n_samples_out, pop_alpha, coi_r, coi_p
   ret[["ancestral_indexes"]] = input_samples_df
   # set proportions
   set_props <- rdirichlet_single(nrow(input_samples_df), alpha = pop_alpha)
-  ret[["set_props"]] = set_props
-  ret[["chrom_sizes"]] = chrom_sizes
+
+  # save population parameters
+  ret[["parameters"]] = list()
+  ret[["parameters"]][["set_props"]] = set_props
+  ret[["parameters"]][["chrom_sizes"]] = chrom_sizes
+  ret[["parameters"]][["pop_alpha"]] = pop_alpha
+  ret[["parameters"]][["coi_r"]] = coi_r
+  ret[["parameters"]][["coi_p"]] = coi_p
+  ret[["parameters"]][["k_s"]] = k_s
+  ret[["parameters"]][["max_k"]] = max_k
+  ret[["parameters"]][["max_coi"]] = max_coi
+  ret[["parameters"]][["rho"]] = rho
   # simulate samples
   ret[["simulated_samples"]] = list()
   for(samp in 1:n_samples_out){

--- a/man/sim_population.Rd
+++ b/man/sim_population.Rd
@@ -11,6 +11,7 @@ sim_population(
   coi_r,
   coi_p,
   k_s,
+  max_k = 20,
   max_coi = 100,
   rho = 7.4e-07,
   chrom_sizes = get_pf3d7_chrom_sizes()
@@ -26,6 +27,8 @@ sim_population(
 \item{coi_r, coi_p}{the r and p parameters to be given to the zero truncated negative binomial distribution COI generator `recombuddy::rztnbinom()` see `?rztnbinom` for more details}
 
 \item{k_s}{the s parameter to be given to the type 1 geometric distribution random generator function `rgeom()` to select for serial meiosis}
+
+\item{max_k}{the maximum k allowed}
 
 \item{max_coi}{the maximum allowable COI}
 


### PR DESCRIPTION
When very large ks get randomly selected (e.g. >20) then the strain alone can take 30-60 seconds to simulate which in turns can make simulations slow considerably